### PR TITLE
Conda activate 4.5.12

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,3 +2,21 @@ conda-zsh-completion
 --------------------
 
 Please see the top of the ``_conda`` file for more info.
+
+--------------------
+To add to .oh-my-zsh (OMZ):
+  1. Clone/download conda-zsh-completion into $ZSH/custom/plugin: ``cd $ZSH/custom/plugin; git clone $CLONEURL``
+  2. Ensure conda is in your path. There are several options, depending on your conda version:
+     - Pre conda 4.4, add ``export PATH="<conda_path>/bin:$PATH"`` to .zshrc
+     - Conda 4.4 and up, add ``. <conda_path>/etc/profile.d/conda.sh`` to .zshrc
+     If you do not know your conda version: ``<conda_path>/bin/conda --version``.
+  3. Append the following lines to your .zshrc:
+     ``fpath+=$ZSH/custom/plugins/conda-zsh-completion``
+     ``compinit conda``
+
+These instructions will not add conda-zsh-completion (CZC) to OMZ as a custom
+plugin, as CZC is not formated as a plugin, and will fail if used as such. But
+it will function correctly and be clean.
+ 
+       
+       

--- a/_conda
+++ b/_conda
@@ -299,8 +299,8 @@ __conda_commands(){
         init:'Initialize conda into a regular environment. (DEPRECATED)'
         package:'Low-level conda package utility. (EXPERIMENTAL)'
         bundle:'Create or extract a "bundle package" (EXPERIMENTAL)'
-        activate:'Init a conda env (dependent on conda.sh in profile)'
-        deactivate:'Leave a conda env'
+        activate:'Init a conda env (conda >= 4.4)'
+        deactivate:'Leave a conda env (conda >= 4.4)'
     )
     external=(
         env:'Manage environments.'

--- a/_conda
+++ b/_conda
@@ -299,6 +299,8 @@ __conda_commands(){
         init:'Initialize conda into a regular environment. (DEPRECATED)'
         package:'Low-level conda package utility. (EXPERIMENTAL)'
         bundle:'Create or extract a "bundle package" (EXPERIMENTAL)'
+        activate:'Init a conda env (dependent on conda.sh in profile)'
+        deactivate:'Leave a conda env'
     )
     external=(
         env:'Manage environments.'
@@ -397,6 +399,10 @@ case $state in
                       '--root[display root environment path]' \
                       '*:packages:__describe_conda_package_available' \
         ;;
+    (activate)
+        _arguments -C $help_opts \
+                   '*:environment:__conda_envs' \
+        ;;
     (help)
         _arguments -C $help_opts \
                       '*:commands:__conda_commands' \
@@ -481,7 +487,7 @@ case $state in
                       '*:packages:{__conda_packages_installed $specifier $environment}' \
         ;;
     (config)
-        # this allows completing multiple keys whet --get is given
+        # this allows completing multiple keys when --get is given
         local -a last_item get_opts
         last_item=$line[$CURRENT-1]
         if (( ${line[(I)--get]} ))  && (( ${__conda_config_keys[(I)$last_item]} )) ; then

--- a/_conda
+++ b/_conda
@@ -400,8 +400,7 @@ case $state in
                       '*:packages:__describe_conda_package_available' \
         ;;
     (activate)
-        _arguments -C $help_opts \
-                   '*:environment:__conda_envs' \
+        _arguments -C '*:environment:__conda_envs' \
         ;;
     (help)
         _arguments -C $help_opts \


### PR DESCRIPTION
Added conda activate/deactivate that auto-completes with the env.
I note that there are 3 PRs that are open and the that there has been no activity for 4 (?) years, so this is clearly a broadcast to the abyss. But I am grateful to @esc for publishing a very useful script. 