### PR TITLE
Add LICENSE file and README badge

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,13 @@
+DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE 
+            Version 2, December 2004 
+
+Copyright (C) 2004 Sam Hocevar <sam@hocevar.net> 
+
+Everyone is permitted to copy and distribute verbatim or modified 
+copies of this license document, and changing it is allowed as long 
+as the name is changed. 
+
+    DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE 
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION 
+
+0. You just DO WHAT THE FUCK YOU WANT TO.

--- a/README.rst
+++ b/README.rst
@@ -2,3 +2,7 @@ conda-zsh-completion
 --------------------
 
 Please see the top of the ``_conda`` file for more info.
+
+<a href="http://www.wtfpl.net/"><img
+       src="http://www.wtfpl.net/wp-content/uploads/2012/12/wtfpl-badge-4.png"
+       width="80" height="15" alt="WTFPL" /></a>


### PR DESCRIPTION
Adds a `LICENSE.txt` file so that GitHub can automatically detect and display the license on the repo home page.

Also adds a WTFPL license badge to the README, for easy identification and fun.

Fixes #18.