### PR TITLE
Ensure plugin is correctly loaded by oh-my-zsh

### DIFF
--- a/_conda
+++ b/_conda
@@ -25,7 +25,7 @@
 # just add it to your $fpath before calling the OMZ or Prezto initialization
 # functions. For example:
 #
-#     git clone https://github.com/esc/conda-zsh-completion ${ZSH_CUSTOM:=~/.oh-my-zsh/custom}/plugins/zsh-completions
+#     git clone https://github.com/esc/conda-zsh-completion ${ZSH_CUSTOM:=~/.oh-my-zsh/custom}/plugins/conda-zsh-completion
 #
 # And add lines in `.zshrc`
 #     plugins=(… conda-zsh-completion)


### PR DESCRIPTION
As we can see [here](https://github.com/robbyrussell/oh-my-zsh/blob/40df67bc3b9b51caa24df5d220487043040d1f9a/oh-my-zsh.sh#L86), the directory name of the plugin must match the plugin name for oh-my-zsh to  correctly load the plugin. This PR updates the doc in `_conda` to reflect this.