### PR TITLE
test if envs dir exists before ls it

### DIFF
--- a/_conda
+++ b/_conda
@@ -53,6 +53,16 @@
 # to your '.zshrc':
 #
 #    zstyle ":conda_zsh_completion:*" sort-envs-by-time true
+# 
+# The completion will display both global environments (envs located in conda_dir/envs and base env)
+# and local environments (located in ~/.conda/envs).
+# If enables sort-envs-by-time, it will display local environments first.
+# To display global environments first, add the following to your '.zshrc':
+#
+#    zstyle ":conda_zsh_completion:*" show-global-envs-first true
+# 
+# If not enables sort-envs-by-time, then all environments will be sorted by alphabetical order,
+# and this option is useless.
 #
 # To forcefully clean the completion cache, look in '~/.zcompcache' and remove
 # file starting with 'conda_'. And/or do 'rm ~/.zcompdump*'.
@@ -143,18 +153,36 @@ local state line context
 local -A opt_args
 
 __conda_envs(){
-    local -a envs unnamed sort
+    local -a envs unnamed sort globalfirst localenvs globalenvs
     local -a ls_opts=("-1")
     local -a describe_opts
     # only parse environments.txt (including unnamed envs) if asked by the user
     zstyle -s ":conda_zsh_completion:*" show-unnamed unnamed
     zstyle -s ":conda_zsh_completion:*" sort-envs-by-time sort
+    zstyle -s ":conda_zsh_completion:*" show-global-envs-first globalfirst
     if test -n "$sort"; then
         ls_opts+=("-t")
         describe_opts+=("-V")
     fi
 
-    envs=($(echo base ; ([[ -d "${${CONDA_EXE}%bin/conda}/envs" ]] && ls $ls_opts ${${CONDA_EXE}%bin/conda}/envs) ; ([[ -d "${HOME:?}/.conda/envs" ]] && ls $ls_opts ${HOME:?}/.conda/envs) ; (test -n "$unnamed" && cat ${HOME:?}/.conda/environments.txt) | cut -f1 -d' '))
+    # global envs (if exists) and base env.
+    globalenvs=($([[ -d "${${CONDA_EXE}%bin/conda}/envs" ]] && ls $ls_opts ${${CONDA_EXE}%bin/conda}/envs))
+    globalenvs+=("base")
+
+    # local envs (if exists).
+    localenvs=($([[ -d "${HOME:?}/.conda/envs" ]] && ls $ls_opts ${HOME:?}/.conda/envs))
+
+    if test -n "$globalfirst"; then
+        envs=($globalenvs $localenvs)
+    else
+        envs=($localenvs $globalenvs)
+    fi
+        
+    # unmaned envs (if show-unammed). 
+    if test -n "$unnamed"; then
+        envs+=($( (test -n "$unnamed" && cat ${HOME:?}/.conda/environments.txt) | cut -f1 -d' '))
+    fi
+
     _describe $describe_opts -t envs 'conda environments' envs
 }
 

--- a/_conda
+++ b/_conda
@@ -143,7 +143,7 @@ local state line context
 local -A opt_args
 
 __conda_envs(){
-    local -a envs
+    local -a envs unnamed sort
     local -a ls_opts=("-1")
     local -a describe_opts
     # only parse environments.txt (including unnamed envs) if asked by the user
@@ -154,7 +154,7 @@ __conda_envs(){
         describe_opts+=("-V")
     fi
 
-    envs=($(ls $ls_opts ${${CONDA_EXE}%bin/conda}/envs && echo base && (test -n "$unnamed" && cat ${HOME:?}/.conda/environments.txt) | cut -f1 -d' '))
+    envs=($(echo base ; ([[ -d "${${CONDA_EXE}%bin/conda}/envs" ]] && ls $ls_opts ${${CONDA_EXE}%bin/conda}/envs) ; ([[ -d "${HOME:?}/.conda/envs" ]] && ls $ls_opts ${HOME:?}/.conda/envs) ; (test -n "$unnamed" && cat ${HOME:?}/.conda/environments.txt) | cut -f1 -d' '))
     _describe $describe_opts -t envs 'conda environments' envs
 }
 


### PR DESCRIPTION
`conda` itself is a standalone application, which means that in some cases,  `${${CONDA_EXE}%bin/conda}/envs` may not exist.

For example, if user install `conda` into their system python environment with `pip`, then `conda` will locate in `/usr/bin/conda`, while `/usr/envs` doesn't exist. The envs create by `conda create` will locate in `$HOME/.conda/envs` in this case.

Directly `ls -1 ${${CONDA_EXE}%bin/conda}/envs` may break `conda activate` completion in this case.