### PR TITLE
Naive Mamba support

### DIFF
--- a/_conda
+++ b/_conda
@@ -1,4 +1,4 @@
-#compdef conda
+#compdef conda mamba
 #description:conda package manager
 #
 # ZSH Completion for conda (http://conda.pydata.org/)


### PR DESCRIPTION
Added `mamba` (https://mamba.readthedocs.io/en/latest/) to the list of commands that trigger a completion. Since mamba's CLI is identical to conda, this simple modification should be enough.